### PR TITLE
Add `getListsForEmail()`

### DIFF
--- a/src/variables/CmListsVariable.php
+++ b/src/variables/CmListsVariable.php
@@ -37,4 +37,9 @@ class CmListsVariable
     {
         return CmLists::getInstance()->campaignmonitor->getActiveSubscribers($listId);
     }
+
+    public function getListsForEmail($email)
+    {
+        return CmLists::getInstance()->campaignmonitor->getListsForEmail($email);
+    }
 }


### PR DESCRIPTION
Requires https://github.com/clearbold/craft-campaignmonitor-service/pull/2 in order to work correctly.